### PR TITLE
关于变量命名strName strPassword 

### DIFF
--- a/CodeStyle.md
+++ b/CodeStyle.md
@@ -173,6 +173,7 @@ bool_switchState, floatBoxHeight
 
 // 可选 常用的类，协商好之后可以团队内使用简写的前缀以缩短代码，这种商定不应被大规模采用
 strName, strPsaaword, btnName, btnPassword
+```
 
 推荐的前缀：
 

--- a/CodeStyle.md
+++ b/CodeStyle.md
@@ -169,7 +169,6 @@ wCell, vcMaster, vToolbar
 
 // 糟糕，数据类型作为前缀
 bool_switchState, floatBoxHeight
-```
 
 // 可选 常用的类，协商好之后可以团队内使用简写的前缀以缩短代码，这种商定不应被大规模采用
 strName, strPsaaword, btnName, btnPassword

--- a/CodeStyle.md
+++ b/CodeStyle.md
@@ -171,6 +171,9 @@ wCell, vcMaster, vToolbar
 bool_switchState, floatBoxHeight
 ```
 
+// 可选 常用的类，协商好之后可以团队内使用简写的前缀以缩短代码，这种商定不应被大规模采用
+strName, strPsaaword, btnName, btnPassword
+
 推荐的前缀：
 
 前缀 | 含义


### PR DESCRIPTION
苹果的一些类，在使用的时候，为了使得符合开始的命名思想。最有区分的内容放后面，通用的大家一眼看上去就能理解的东西 放前面。所以 在例如使用用户名 密码的时候。strName strPassword 用以代码密码文本。btnName btnPassword代表按钮  textFeildName 代表编辑框
